### PR TITLE
Feat/provide swagger only in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ To run the server locally, follow these steps:
 3. Build with `npm run build`.
 4. Start the server with `npm start` or `npm run dev` for development mode.
 
-
 ## API Endpoints
-Explore the available endpoints by running the server and visiting the `localhost:3000/api-docs` route.
+Explore the available endpoints by running the server in dev mode (`npm run dev`) and visiting the `localhost:3000/api-docs` route.
 This documentation is auto-generated through comments in the code.
 
 ## Authentication & Authorization

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/multer": "^1.4.11",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
@@ -5515,11 +5516,27 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7622,8 +7639,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "2.1.0",
@@ -13838,7 +13854,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15019,7 +15034,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -15031,7 +15045,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -16489,7 +16502,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx tsc",
     "start": "node dist/src/server.js",
-    "dev": "nodemon src/server.ts",
+    "dev": "cross-env ENABLE_DOCS=true nodemon src/server.ts",
     "test": "jest"
   },
   "repository": {
@@ -26,6 +26,7 @@
     "@types/multer": "^1.4.11",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -14,7 +14,9 @@ const router = express.Router();
 // Auto-generated Swagger docs
 const swaggerDocs = generateSwaggerDocs();
 
-router.use("/api-docs", serveSwaggerUi(), setupSwaggerUi(swaggerDocs));
+if (process.env.ENABLE_DOCS === "true") {
+  router.use("/api-docs", serveSwaggerUi(), setupSwaggerUi(swaggerDocs));
+}
 router.use("/", categoryRoutes);
 router.use("/", productRoutes);
 router.use("/", subCategoryRoutes);

--- a/src/utils/swaggerConfig.ts
+++ b/src/utils/swaggerConfig.ts
@@ -33,7 +33,7 @@ export const generateSwaggerDocs = () => {
 };
 
 export const serveSwaggerUi = () => {
-  console.info(`Docs available at http://localhost:${port}/api-docs`);
+  console.log(`[server]: Docs available at http://localhost:${port}/api-docs`);
   return swaggerUi.serve;
 };
 


### PR DESCRIPTION
This PR closes #47 .
Now the `/api-docs` endpoint is provided only if the server is run in dev mode (`npm run dev`).